### PR TITLE
make sessionInit, sessionClose functions to be public

### DIFF
--- a/libssh2/libssh2.cabal
+++ b/libssh2/libssh2.cabal
@@ -1,6 +1,6 @@
 Name:                libssh2
 
-Version:             0.2
+Version:             0.2.0.1
 
 Synopsis:            FFI bindings to libssh2 SSH2 client library (http://libssh2.org/)
 

--- a/libssh2/libssh2.cabal
+++ b/libssh2/libssh2.cabal
@@ -61,6 +61,7 @@ Library
                        bytestring >= 0.9
 
   Extra-libraries:     "ssh2"
+  pkgconfig-depends:   libssh2 >= 1.2.8
   GHC-Options:         -Wall
   
   -- Other-modules:       

--- a/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Errors.chs
@@ -111,6 +111,9 @@ instance IntResult (Int, a, b) where
 instance IntResult (Int, a, b, c) where
   intResult = \(i, _, _, _) -> i
 
+instance IntResult CInt where
+  intResult = fromIntegral
+
 instance IntResult CLong where
   intResult = fromIntegral
 

--- a/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
+++ b/libssh2/src/Network/SSH/Client/LibSSH2/Foreign.chs
@@ -291,11 +291,7 @@ writeChannel ch bs =
                            $ {# call channel_write_ex #} (toPointer ch) 
                                                          0 
                                                          (cstr `plusPtr` offset) 
-#ifdef mingw32_HOST_OS
                                                          (fromIntegral len)
-#else
-                                                         len
-#endif
       if fromIntegral written < len 
         then go (offset + fromIntegral written) (len - fromIntegral written) cstr
         else return ()
@@ -364,7 +360,7 @@ writeChannelFromHandle ch h =
                   0
                   (plusPtr buffer written)
                   (fromIntegral size)
-      send (written + fromIntegral sent) (size - sent) buffer
+      send (written + fromIntegral sent) (size - fromIntegral sent) buffer
 
     bufferSize = 0x100000
 


### PR DESCRIPTION
This patch adds an ability to "break-out" of ssh2 session scope, i.e.

```
session <- sessionInit 
someActionsWithSession session
someIOOrOtherMonadActions
someActionsWithSession session
sessionClose
```

Code can still can be save if sessionInit sessionClose functions is used in
conjunction with region library like resourcet.

All changes in backward compatible.
